### PR TITLE
Fix PermissionsBuilder:AddPermission return value

### DIFF
--- a/Package/Classes/Builders/PermissionsBuilder.luau
+++ b/Package/Classes/Builders/PermissionsBuilder.luau
@@ -132,7 +132,7 @@ PermissionsBuilder.Interface.Permissions = Enumerate.new({
 ]=]
 function PermissionsBuilder.Prototype.addPermission(self: PermissionsBuilder, permission: number)
 	if table.find(self.permissions, permission) then
-		return
+		return self
 	end
 
 	table.insert(self.permissions, permission)


### PR DESCRIPTION
Before the return type was `PermissionsBuilder?`, preventing method chaining. This PR fixes that.