### PR TITLE
bugfix: rename "fetchGuildChannel" method of DiscordGuild to specify it is asynchronous

### DIFF
--- a/Package/Classes/Objects/DiscordGuild.luau
+++ b/Package/Classes/Objects/DiscordGuild.luau
@@ -367,11 +367,11 @@ end
 --[=[
 	Fetches all channels in the guild asynchronously.
 
-	@method fetchGuildChannels
+	@method fetchGuildChannelsAsync
 	@return Vendor.Future
 	@within Objects.DiscordGuild
 ]=]
-function DiscordGuild.Prototype.fetchGuildChannels(self: DiscordGuild)
+function DiscordGuild.Prototype.fetchGuildChannelsAsync(self: DiscordGuild)
 	return Future.try(function()
 		local guildChannels = self.discordClient.discordGateway
 			:getAsync(


### PR DESCRIPTION
This is a breaking change.

If you want to avoid the breaking change, something like this snippet could be added:
```luau
function DiscordGuild.Prototype.fetchGuildChannelsAsync(self: DiscordGuild)
	return self:fetchGuildChannelsAsync()
end
```

No idea if you want to change the method name or not, I'll leave this pull request just in case.