### PR TITLE
bug fixes

### DIFF
--- a/packages/builders/src/message/components/button.luau
+++ b/packages/builders/src/message/components/button.luau
@@ -106,7 +106,7 @@ function Button.Prototype.build(self: Button): JSON
 
 	return {
 		type = 2,
-		style = apiTypes.channel.ButtonStyle[self.style],
+		style = apiTypes.message.ButtonStyle[self.style],
 		label = self.label,
 		emoji = self.emoji,
 		custom_id = self.customId,

--- a/packages/classes/src/interaction/behaviour/interactable.luau
+++ b/packages/classes/src/interaction/behaviour/interactable.luau
@@ -139,7 +139,7 @@ function Interaction.Prototype.getResponseAsync(self: Interaction, threadId: str
 
 	return future.Future.new(function()
 		local response = rest.interaction
-			.getOriginalInteractionResponseAsync(request, self.id, self.token, {
+			.getOriginalInteractionResponseAsync(request, self.state.applicationId, self.token, {
 				threadId = threadId,
 			})
 			:await()
@@ -165,7 +165,7 @@ function Interaction.Prototype.editResponseAsync(
 		request:setFlag("FormdataRequest", true)
 
 		local response = rest.interaction
-			.editOriginalInteractionResponseAsync(request, self.id, self.token, messageJSON, {
+			.editOriginalInteractionResponseAsync(request, self.state.applicationId, self.token, messageJSON, {
 				threadId = threadId,
 			})
 			:await()
@@ -184,7 +184,7 @@ function Interaction.Prototype.deleteResponseAsync(self: Interaction)
 	local request = self.state.rest:newRequest()
 
 	return future.Future.new(function()
-		local response = rest.interaction.deleteOriginalInteractionResponseAsync(request, self.id, self.token):await()
+		local response = rest.interaction.deleteOriginalInteractionResponseAsync(request, self.state.applicationId, self.token):await()
 
 		assert(response:isOk(), tostring(response:unwrapErr()))
 
@@ -208,7 +208,7 @@ function Interaction.Prototype.createFollowupResponseAsync(
 		request:setFlag("FormdataRequest", true)
 
 		local response = rest.interaction
-			.createFollowupMessageAsync(request, self.id, self.token, messageJSON, {
+			.createFollowupMessageAsync(request, self.state.applicationId, self.token, messageJSON, {
 				wait = true,
 				threadId = threadId,
 			})
@@ -229,7 +229,7 @@ function Interaction.Prototype.getFollowupResponseAsync(self: Interaction, messa
 
 	return future.Future.new(function()
 		local response = rest.interaction
-			.getFollowupMessageAsync(request, self.id, self.token, messageId, {
+			.getFollowupMessageAsync(request, self.state.applicationId, self.token, messageId, {
 				threadId = threadId,
 			})
 			:await()
@@ -256,7 +256,7 @@ function Interaction.Prototype.editFollowupResponseAsync(
 		request:setFlag("FormdataRequest", true)
 
 		local response = rest.interaction
-			.editFollowupMessageAsync(request, self.id, self.token, messageId, messageJSON, {
+			.editFollowupMessageAsync(request, self.state.applicationId, self.token, messageId, messageJSON, {
 				threadId = threadId,
 			})
 			:await()
@@ -275,7 +275,7 @@ function Interaction.Prototype.deleteFollowupResponseAsync(self: Interaction, me
 	local request = self.state.rest:newRequest()
 
 	return future.Future.new(function()
-		local response = rest.interaction.deleteFollowupMessageAsync(request, self.id, self.token, messageId):await()
+		local response = rest.interaction.deleteFollowupMessageAsync(request, self.state.applicationId, self.token, messageId):await()
 
 		assert(response:isOk(), tostring(response:unwrapErr()))
 

--- a/packages/classes/src/interaction/behaviour/interactable.luau
+++ b/packages/classes/src/interaction/behaviour/interactable.luau
@@ -52,8 +52,7 @@ function Interaction.Prototype.deferAsync(self: Interaction)
 
 		local response = rest.interaction
 			.createInteractionResponseAsync(request, self.id, self.token, {
-				type = 5,
-				data = {},
+				type = 5
 			}, {
 				withResponse = false,
 			})

--- a/packages/websocket/src/manager.luau
+++ b/packages/websocket/src/manager.luau
@@ -150,9 +150,6 @@ function Manager.Prototype.connectAsync(
 				stdPolyfills.task.wait(CONCURRENT_IDENTIFY_YIELD)
 			end
 
-			self.logger:debug(`Connecting Shard '{shardIndex - 1}' to Discord Gateway`)
-
-			shardInstance:connectAsync(websocketUrl, self.webSocketVersion):await()
 			shardInstance.onSocketDispatch:listen(function(event)
 				self.onDispatch:invoke({
 					shardId = shardIndex - 1,
@@ -199,6 +196,10 @@ function Manager.Prototype.connectAsync(
 					errorCode = code,
 				})
 			end)
+
+			self.logger:debug(`Connecting Shard '{shardIndex - 1}' to Discord Gateway`)
+
+			shardInstance:connectAsync(websocketUrl, self.webSocketVersion):await()
 		end
 	end)
 end


### PR DESCRIPTION
<!--- Please provide a general summary of your changes in the title above -->

## Pull request type

<!-- Please try to limit your pull request to one type, submit multiple pull requests if needed. -->

Please check the type of change your PR introduces:

- [X] Bugfix
- [ ] Feature
- [ ] Other (please describe):

## What is the current behavior?

<!-- Please describe the current behavior that you are modifying, or link to a relevant issue. -->

### Builders.Button:build()
```luau
builders.message.components.button.new({
	style = "Blurple",
	label = "hi",
	customId = "hello_world"
}):build()
```
would error as `build` tried to index api_types.channel.ButtonStyle (nil) with "Blurple"


### Classes.Interactable:deferAsync()
```luau
bot.onModalInteraction:listen(function(modal)
	warn(modal:deferAsync():await())
end)
```
would error as `deferAsync` added an incorrect data field to the request


### WebSocket.Manager:connectAsync()
shardInstance:connectAsync(...):await() would yield and make some emitters not being able to listen() in time
causing bot:connectAsync():await() to infinitely yield as it waits for webSocketManager.onConnected to be invoked

## What is the new behavior?

<!-- Please describe the behavior or changes that are being added by this PR. -->
bug fixes
- `api_types.channel.ButtonStyle` -> `api_types.message.ButtonStyle`
- removed `data = {}` from deferAsync request
- moved `shardInstance:connectAsync` to allow listeners to be set in time 

## Other information

currently deferAsync only offers one type (5), would it be possible to see type 6 in the future?
type 5 makes the bot reply to the interaction with "{bot name} is thinking..."
while type 6 just sends an acknowledgement to discord
<!-- Any other information that is important to this PR such as screenshots of how the component looks before and after the change. -->
