### PR TITLE
fix(commands): add guild install intergration

### DIFF
--- a/packages/commands/src/defaults/help.luau
+++ b/packages/commands/src/defaults/help.luau
@@ -203,6 +203,7 @@ return function(registryInstance: registry.Registry): command.CommandDefinition
 			:setDescription("List all available commands")
 			:setType("ChatInput")
 			:addIntegrationType("UserInstall")
+			:addIntegrationType("GuildInstall")
 			:addContext("Guild")
 			:addContext("BotDm")
 			:addContext("PrivateChannel")


### PR DESCRIPTION
<!--- Please provide a general summary of your changes in the title above -->

## Pull request type

<!-- Please try to limit your pull request to one type, submit multiple pull requests if needed. -->

Please check the type of change your PR introduces:

- [x] Bugfix
- [ ] Feature
- [ ] Other (please describe):

## What is the current behavior?

<!-- Please describe the current behavior that you are modifying, or link to a relevant issue. -->

As of right now, the built in `/help` command does not properly add itself as a Guild Integration, thus only allowing the user to utilize the command if the bot has the ability to be installed as a personal application, instead of it being scoped to both user-focused bots and server-focused bots.

## What is the new behavior?

<!-- Please describe the behavior or changes that are being added by this PR. -->

With this pull request, the `/help` command will now properly register itself as a Guild and User Integration, so that it may be utilized in the server the application resides in.

## Other information

<!-- Any other information that is important to this PR such as screenshots of how the component looks before and after the change. -->

Not applicable.